### PR TITLE
Updates README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [Full Changelog](https://github.com/andrewmcodes/bundler-audit-action/compare/v0.1.0...HEAD)
 
+
+## [0.2.0](https://github.com/andrewmcodes/bundler-audit-action/tree/v0.2.0)
+
+  - Added the ability to pass arguments to the `bundle audit check` command ([PR#5](https://github.com/andrewmcodes/bundler-audit-action/pull/5), [doc](https://github.com/puria/bundler-audit-action#advanced-usage)).
+  - If present, the `.bundler-audit.yml` is read ([PR#5](https://github.com/andrewmcodes/bundler-audit-action/pull/5), [doc](https://github.com/puria/bundler-audit-action#advanced-usage)).
+
+[Full Changelog](https://github.com/andrewmcodes/bundler-audit-action/compare/v0.1.0...v0.2.0)
+
 **Merged pull requests:**
 
 - Fix issue with the changelog action and update the changelog [\#4](https://github.com/andrewmcodes/bundler-audit-action/pull/4) ([andrewmcodes](https://github.com/andrewmcodes))

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ jobs:
 ```
 
 ### Advanced Usage
-The `options` argument exists to allow you to pass options to the audit command, just like you would locally:
+By default, you can add he ignored CVE into the standard `.bundler-audit.yml` as described [here](https://github.com/rubysec/bundler-audit#configuration-file).
+Moreover, the `options` argument exists to allow you to pass options to the audit command, just like you would locally:
 
 ```yaml
 name: Bundler Audit


### PR DESCRIPTION
# Enhancement on doc

## Description

This PR add a version to the CHANGELOG (`0.2.0`) with the description of what changed and a further pargraph on `README.md` to describe the chance to use the standard `.bundler-audit.yml` to add ignored CVEs.

## Why should this be added

To improve the doc.

## Checklist

- [x] My code follows the style guidelines of this project
